### PR TITLE
diag/network: Fix typo (toss 2877)

### DIFF
--- a/diags/network.t
+++ b/diags/network.t
@@ -107,7 +107,7 @@ for i in $(seq 0 $(($numdev - 1))); do
         fi
     fi
     if [ -n "$duplex" ]; then
-        gotduplex="$(getmode $dev)"
+        gotduplex="$(getduplex $dev)"
         if [ "$duplex" != "$gotduplex" ]; then
             diag_fail "$dev duplex '$gotduplex', expected '$duplex'"
         else
@@ -115,7 +115,7 @@ for i in $(seq 0 $(($numdev - 1))); do
         fi
     fi
     if [ -n "$speed" ]; then
-        gotspeed="$(getmode $dev)"
+        gotspeed="$(getspeed $dev)"
         if [ "$speed" != "$gotspeed" ]; then
             diag_fail "$dev speed '$gotspeed', expected '$speed'"
         else


### PR DESCRIPTION
Fix egregious cut and paste disaster found by Jim Silva
and documented in TOSS-2877