### PR TITLE
Need to tick up numtests if checking speed too, or risk exiting before all tests are run.

### DIFF
--- a/diags/network.t
+++ b/diags/network.t
@@ -76,6 +76,7 @@ numtests=$numdev
 for i in $(seq 0 $(($numdev - 1))); do
     [ -n "${DIAG_NETWORK_MTU[$i]}" ] && numtests=$(($numtests + 1))
     [ -n "${DIAG_NETWORK_MODE[$i]}" ] && numtests=$(($numtests + 1))
+    [ -n "${DIAG_NETWORK_SPEED[$i]}" ] && numtests=$(($numtests + 1))
 done
 diag_plan $(($numtests))
 


### PR DESCRIPTION
If $DIAG_NETWORK_SPEED [$i] is defined in the nodediag config,  $numtests needs to be ticked up as well or risk exiting before all of the tests are run.