### PR TITLE
build system enhancements and prep for 1.2.23 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Mark Grondona
 Tim Randles
 Jim Silva
 Cameron Harr
+Phil Regier

--- a/META
+++ b/META
@@ -1,7 +1,0 @@
-##
-# Metadata for RPM/TAR makefile targets
-##
-  Meta:		1
-  Name:		nodediag
-  Version:	1.2.22
-  Release:	1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+all:
+	@echo Nothing to do
+
+clean:
+	rm -f nodediag-*.tar.gz
+
+dist:
+	@scripts/mkdist
+
+check:
+	cd test && ../scripts/runtests

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,17 @@
 =========================================================================
+Release Notes for nodediag version 1.2.23                     06 Dec 2018
+=========================================================================
+
+* Allow alternate interface dev name to be specified for network.t test
+  (Phil Regier)
+
+* Add 'make dist' and 'make check' targets.
+
+* Ensure failing tests result in nonzero exit code.
+
+* Update Dell T5500 PCI vendor name for Broadcom.
+
+=========================================================================
 Release Notes for nodediag version 1.2.22                     30 May 2018
 =========================================================================
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Nodediag provides an extensible
-[TAP](http://testanything.org/wiki/index.php/Main_Page TAP)
+[TAP](http://testanything.org/wiki/index.php/Main_Page)
 framework for executing node diagnostic checks at system startup.
 
 Tests installed in `/etc/nodediag.d/` are run in parallel by the `nodediag`

--- a/nodediag.spec
+++ b/nodediag.spec
@@ -1,7 +1,7 @@
 Name: nodediag
-Version:
-Release:
-Source:
+Version: 1.2.23
+Release: 1
+Source: %{name}-%{version}.tar.gz
 License: GPL
 Summary: Tests to verify hardware
 Group: Applications/Devel

--- a/scripts/mkdist
+++ b/scripts/mkdist
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if test $# -gt 1; then
+    echo "Usage: mkdist [git-tag]" >&2
+    exit 1
+fi
+VERSION=$1
+if test -z "$VERSION"; then
+    VERSION=$(git describe --always | awk '/.*/ {printf "%s",$1; exit}')
+fi
+
+echo "Creating ${VERSION}.tar.gz"
+
+git archive --format=tar --prefix=nodediag-${VERSION}/ ${VERSION} \
+		| gzip >nodediag-${VERSION}.tar.gz

--- a/scripts/runtests
+++ b/scripts/runtests
@@ -7,36 +7,29 @@ fi
 
 export NODEDIAGDIR=../diags
 
+fail_count=0
+
 for file in */dmidecode; do
+	platform=$(basename $(dirname $file))
+	echo $platform: running dmi.t on cached config and dmidecode dump file
 	export DMIDECODE_DUMP_FILE=$file
-	for cfg in $(dirname $file)/dmi*.conf; do
-		export NODEDIAGCONF=$cfg
-		$NODEDIAGDIR/dmi.t
-	done
-	unset NODEDIAGCONF
-	tmpfile=$(mktemp) || exit 1
-	$NODEDIAGDIR/dmi.t -c >$tmpfile
-	if diff -q $(dirname $file)/dmi.conf $tmpfile; then
-		echo $(dirname $file): config file OK
-	else
-		echo $(dirname $file): config file FAIL
+	export NODEDIAGCONF=$(dirname $file)/dmi.conf
+	if $NODEDIAGDIR/dmi.t | grep 'not ok'; then
+		fail_count=$(($fail_count+1))
 	fi
-	rm -f $tmpfile
+	unset NODEDIAGCONF
 done
 
 for file in */lspci; do
+	platform=$(basename $(dirname $file))
+	echo $platform: running pci.t on cached config and lspci dump file
 	export LSPCI_DUMP_FILE=$file
-	for cfg in $(dirname $file)/pci*.conf; do
-		export NODEDIAGCONF=$cfg
-		$NODEDIAGDIR/pci.t
-	done
-	unset NODEDIAGCONF
-	tmpfile=$(mktemp) || exit 1
-	$NODEDIAGDIR/pci.t -c >$tmpfile
-	if diff -q $(dirname $file)/pci.conf $tmpfile; then
-		echo $(dirname $file): config file OK
-	else
-		echo $(dirname $file): config file FAIL
+	export NODEDIAGCONF=$(dirname $file)/pci*.conf
+	if $NODEDIAGDIR/pci.t | grep 'not ok'; then
+		fail_count=$(($fail_count+1))
 	fi
-	rm -f $tmpfile
+	unset NODEDIAGCONF
 done
+
+echo Failed $fail_count tests >&2
+test $fail_count -eq 0 || exit 1

--- a/scripts/runtests
+++ b/scripts/runtests
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if ! test -d ../diags; then
+	echo Must be run within test directory >&2
+	exit 1
+fi
+
 export NODEDIAGDIR=../diags
 
 for file in */dmidecode; do

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,2 +1,0 @@
-check:
-	./tconfig

--- a/test/T5500/pci.conf
+++ b/test/T5500/pci.conf
@@ -10,7 +10,7 @@ DIAG_PCI_SPEED[1]="2.5GT/s"
 DIAG_PCI_WIDTH[1]="x16"
 #
 DIAG_PCI_SLOT[2]="06:00.0"
-DIAG_PCI_NAME[2]="Broadcom Corporation NetXtreme BCM5761 Gigabit Ethernet PCIe (rev 10)"
+DIAG_PCI_NAME[2]="Broadcom Limited NetXtreme BCM5761 Gigabit Ethernet PCIe (rev 10)"
 DIAG_PCI_SPEED[2]="2.5GT/s"
 DIAG_PCI_WIDTH[2]="x1"
 #


### PR DESCRIPTION
I was just going to tag so that we could push out @philregier's change in a release, and noticed (yet again, and my bad) what a sorry state the build system is for this project, so in addition to prepping for the release, I added working `make check` and `make dist` targets in a top level Makefile, and fixed a test failure.

The test failure was just a vendor rename in the kernel PCI table.  The fact that tests (and deployed `sysconfig/nodediag` files) are fragile with respect to this is a problem that we may want to address in the future, but for now I just updated the one failing vendor name and verified the new one works on TOSS3 and my Ubuntu 18.04 LTS desktop.  It was the T5500 platform which is just my desktop, so isn't a production concern.

Anyway, nothing that requires significant review at this point.  The substantive change for the release is  one contribution.