### PR TITLE
Fix unquoted variables in pci diag test

### DIFF
--- a/diags/pci.t
+++ b/diags/pci.t
@@ -100,14 +100,14 @@ which lspci >/dev/null 2>&1 || diag_plan_skip "lspci is not installed"
 diag_plan $(($numdev * 3))
 
 for i in $(seq 0 $(($numdev - 1))); do
-    location=${DIAG_PCI_SLOT[$i]}
-    name=$(echo ${DIAG_PCI_NAME[$i]}|normalize_whitespace)
-    speed=${DIAG_PCI_SPEED[$i]}
-    width=${DIAG_PCI_WIDTH[$i]}
+    location="${DIAG_PCI_SLOT[$i]}"
+    name=$(echo "${DIAG_PCI_NAME[$i]}"|normalize_whitespace)
+    speed="${DIAG_PCI_SPEED[$i]}"
+    width="${DIAG_PCI_WIDTH[$i]}"
 
     if [ -n "$name" ] && [ -n "$location" ] ; then
         gotname=$(getname $location)
-        if [ "$name" != "$gotname" ] && ! [[ "$gotname" =~ $name ]]; then
+        if [ "$name" != "$gotname" ] && ! [[ "$gotname" =~ "$name" ]]; then
             diag_fail "$location name $gotname, expected $name"
         else
             diag_ok "$location name $gotname"


### PR DESCRIPTION
Bash string processing can cause the test's configuration variables to be misinterpreted unless they are quoted. 

We discovered that when the test checks for a device with a name containing `[*]` in the context of a directory that contains a one-character filename that matches any characters between the braces in `[*]`, the string is replaced with the name of that file.

For example, on a machine where `/l` is a directory and the PCI test is run in `/`:
```
DIAG_PCI_NAME[2]="Matrox Electronics Systems Ltd. MGA G200e [Pilot] ServerEngines (SEP1) (rev 05)"
```
is evaluated as:
```
"Matrox Electronics Systems Ltd. MGA G200e l ServerEngines (SEP1) (rev 05)"
```