### PR TITLE
Correct zpool and zfs properties tests

### DIFF
--- a/diags/zfs-properties.t
+++ b/diags/zfs-properties.t
@@ -70,11 +70,11 @@ function verify_property {
 	propval=$(getprop ${dataset} ${propname})
 
 	if [ -z "${propval}" ] ; then
-		diag_fail "dataset ${dataset} property ${propname} does not exist" >&2
+		diag_fail "dataset ${dataset} property ${propname} does not exist"
 	elif [ "${propval}" != ${expectedval} ] ; then
-		diag_fail "dataset ${dataset} property ${propname} is ${propval}, expected ${expectedval}" >&2
+		diag_fail "dataset ${dataset} property ${propname} is ${propval}, expected ${expectedval}"
 	else
-		diag_ok "dataset ${dataset} property ${propname} is ${propval}" >&2
+		diag_ok "dataset ${dataset} property ${propname} is ${propval}"
 	fi
 }
 
@@ -129,14 +129,14 @@ function list_datasets {
 diag_handle_args "$@"
 
 which zfs >/dev/null 2>&1 || diag_plan_skip "zfs command not found"
-[ -z "$(list_datasets)" ] &&  diag_plan_skip "no ZFS datasets" >&2
+[ -z "$(list_datasets)" ] &&  diag_plan_skip "no ZFS datasets"
 
 #
 # Count tests and declare them
 #
 num_tests=0
 foreach_dataset_and_property count_tests
-[ $num_tests -eq 0 ] &&  diag_plan_skip "no ZFS dataset checks" >&2
+[ $num_tests -eq 0 ] &&  diag_plan_skip "no ZFS dataset checks"
 diag_plan $num_tests
 
 #

--- a/diags/zfs-properties.t
+++ b/diags/zfs-properties.t
@@ -11,6 +11,11 @@ source ${NODEDIAGDIR:-/etc/nodediag.d}/functions-tap || exit 1
 function diagconfig {
 	local idx=0
 
+	if ! which zfs >/dev/null 2>&1; then
+		echo "# zfs command not found"
+		return 1
+	fi
+
 	for dataset in $(list_datasets); do
 		echo "DIAG_ZFS_DATASET_NAME[$idx]=^${dataset}$"
 		echo "DIAG_ZFS_RECORDSIZE[$idx]=$(getprop ${dataset} recordsize)"
@@ -121,11 +126,10 @@ function list_datasets {
 	zfs list -H | awk '{print $1}'
 }
 
-which zfs >/dev/null 2>&1 || diag_plan_skip "zfs not installed"
-
-[ -z "$(list_datasets)" ] &&  diag_plan_skip "no ZFS datasets" >&2
-
 diag_handle_args "$@"
+
+which zfs >/dev/null 2>&1 || diag_plan_skip "zfs command not found"
+[ -z "$(list_datasets)" ] &&  diag_plan_skip "no ZFS datasets" >&2
 
 #
 # Count tests and declare them

--- a/diags/zpool-properties.t
+++ b/diags/zpool-properties.t
@@ -67,11 +67,11 @@ function verify_property {
 	propval=$(getprop ${pool} ${propname})
 
 	if [ -z "${propval}" ] ; then
-		diag_fail "pool ${pool} property ${propname} does not exist" >&2
+		diag_fail "pool ${pool} property ${propname} does not exist"
 	elif [ "${propval}" != ${expectedval} ] ; then
-		diag_fail "pool ${pool} property ${propname} is ${propval}, expected ${expectedval}" >&2
+		diag_fail "pool ${pool} property ${propname} is ${propval}, expected ${expectedval}"
 	else
-		diag_ok "pool ${pool} property ${propname} is ${propval}" >&2
+		diag_ok "pool ${pool} property ${propname} is ${propval}"
 	fi
 }
 
@@ -122,14 +122,14 @@ function list_pools {
 diag_handle_args "$@"
 
 which zpool >/dev/null 2>&1 || diag_plan_skip "zpool command not found"
-[ -z "$(list_pools)" ] &&  diag_plan_skip "no ZFS pools" >&2
+[ -z "$(list_pools)" ] &&  diag_plan_skip "no ZFS pools"
 
 #
 # Count tests and declare them
 #
 num_tests=0
 foreach_pool_and_property count_tests
-[ $num_tests -eq 0 ] &&  diag_plan_skip "no ZFS pool checks" >&2
+[ $num_tests -eq 0 ] &&  diag_plan_skip "no ZFS pool checks"
 diag_plan $num_tests
 
 #

--- a/diags/zpool-properties.t
+++ b/diags/zpool-properties.t
@@ -11,6 +11,11 @@ source ${NODEDIAGDIR:-/etc/nodediag.d}/functions-tap || exit 1
 function diagconfig {
 	local idx=0
 
+	if ! which zpool >/dev/null 2>&1; then
+		echo "# zpool command not found"
+		return 1
+	fi
+
 	for pool in $(list_pools); do
 		echo "DIAG_ZPOOL_NAME[$idx]=^${pool}$"
 		echo "DIAG_ZPOOL_AUTOREPLACE[$idx]=$(getprop ${pool} autoreplace)"
@@ -114,11 +119,10 @@ function list_pools {
 	zpool list -H | awk '{print $1}'
 }
 
-which zfs >/dev/null 2>&1 || diag_plan_skip "zfs not installed"
-
-[ -z "$(list_pools)" ] &&  diag_plan_skip "no ZFS pools" >&2
-
 diag_handle_args "$@"
+
+which zpool >/dev/null 2>&1 || diag_plan_skip "zpool command not found"
+[ -z "$(list_pools)" ] &&  diag_plan_skip "no ZFS pools" >&2
 
 #
 # Count tests and declare them


### PR DESCRIPTION
The tests did not correctly handle the arguments (e.g. "-c") if the zfs or zpool command was not found.

In addition, output from diag_fail, diag_ok, and other helpers was redirected to stderr when it need not be.

Partially fixes #15 