### PR TITLE
Add lustre:autodegrade property validation for Lustre OST datasets

### DIFF
--- a/diags/zfs-properties.t
+++ b/diags/zfs-properties.t
@@ -24,6 +24,7 @@ function diagconfig {
 		echo "DIAG_ZFS_XATTR[$idx]=$(getprop ${dataset} xattr)"
 		echo "DIAG_ZFS_CANMOUNT[$idx]=$(getprop ${dataset} canmount)"
 		echo "DIAG_ZFS_COMPRESSION[$idx]=$(getprop ${dataset} compression)"
+		echo "DIAG_ZFS_AUTODEGRADE[$idx]=$(getprop ${dataset} lustre:autodegrade)"
 		echo '#'
 		idx=$((idx+1))
 	done
@@ -119,6 +120,7 @@ function foreach_dataset_and_property {
 			handle_test $action ${dataset} canmount    ${DIAG_ZFS_CANMOUNT[$idx]}
 			handle_test $action ${dataset} compression ${DIAG_ZFS_COMPRESSION[$idx]}
 			handle_test $action ${dataset} redundant_metadata ${DIAG_ZFS_RDNT_MD[$idx]}
+			handle_test $action ${dataset} lustre:autodegrade ${DIAG_ZFS_AUTODEGRADE[$idx]}
 
 		done
 	done


### PR DESCRIPTION
## Summary
Add support for validating the ZFS user property `lustre:autodegrade` for Lustre OST datasets.

## Changes
- Added collection of `lustre:autodegrade` property in `diagconfig()` function (line 27)
- Added validation of `lustre:autodegrade` property in `foreach_dataset_and_property()` function (line 123)
- Property validation follows the same pattern as existing ZFS properties

## Configuration Required
Users deploying this change **must** add the `DIAG_ZFS_AUTODEGRADE` configuration to `/etc/sysconfig/nodediag` to enable validation.

### Example Configuration
```bash
# For Lustre OST datasets, add to /etc/sysconfig/nodediag:
DIAG_ZFS_DATASET_NAME[0]="yuba.*/ost1"
DIAG_ZFS_RECORDSIZE[0]="4M"
DIAG_ZFS_DNODESIZE[0]="auto"
DIAG_ZFS_XATTR[0]="sa"
DIAG_ZFS_CANMOUNT[0]="off"
DIAG_ZFS_COMPRESSION[0]="lz4"
DIAG_ZFS_AUTODEGRADE[0]="on"
```

**Note:** The `DIAG_ZFS_AUTODEGRADE[0]="on"` configuration is required for this feature to function. Without it, the property will not be validated.

## Testing
- Verified shell syntax with `bash -n diags/zfs-properties.t` ✅ (exit code 0)
- Code follows the same pattern as existing ZFS property checks
- Tested on local workstation with syntax validation

## Justification
Lustre OST datasets require the ZFS user property `lustre:autodegrade=on` to be set. This change allows nodediag to detect configuration drift automatically by validating that Lustre OST datasets have this property correctly configured.