### PR TITLE
dmi: allow GiB units on Memory Devices Size value

### DIFF
--- a/diags/dmi.t
+++ b/diags/dmi.t
@@ -84,7 +84,8 @@ getmemtot()
     local total=0
 
     for n in `dmi_stanza "Memory Device" | awk '/Size:.*MB/ { print $2 }'` \
-         `dmi_stanza "Memory Device" | awk '/Size:.*GB/ { print $2*1024 }'`; do
+         `dmi_stanza "Memory Device" | awk '/Size:.*GB/ { print $2*1024 }'` \
+         `dmi_stanza "Memory Device" | awk '/Size:.*GiB/ { print $2*1024 }'`; do
         [ "$n" != "No" ] && total=$(($total + $n))
     done
     echo $total


### PR DESCRIPTION
Problem: on newer redhat releases, Memory Devices Size value is reported in GiB units, not GB units.

Match either unit.  Tested on rhel 8,9,10.

Bug report and tested fix courtesy Trent D'Hooge.

Fixes #23