### PR TITLE
Use systemd on RHEL >= 10 and Fedora >= 40, preserve SysVinit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ tapwrap:         Run non-TAP tests: nvidia
 tw:              Check 3ware cards
 ```
 
-An init script is provided so diagnostics can be run at startup, with
-the (verbose) results redirected to `/var/log/nodediag`.
+An init script (SysVinit) or systemd unit file is provided so diagnostics
+can be run at startup. Packages built for RHEL >= 10 or Fedora >= 40 include
+the systemd unit and log to journald (view with `journalctl -u nodediag.service`).
+Packages built for older releases include the init script and log to `/var/log/nodediag`.
+
 Alternatively `nodediag` can be run as part of a cluster bringup
 procedure, determining whether a node is fit to start cluster services;
 or as part of a resource manager epilog between batch jobs to detect

--- a/nodediag.service
+++ b/nodediag.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=Nodediag
-After=syslog.target network.target
+Description=Node Diagnostic Tests
+After=network.target
 
 [Service]
+Type=oneshot
 ExecStart=/usr/bin/nodediag -s -v
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/nodediag.spec
+++ b/nodediag.spec
@@ -10,8 +10,19 @@ Requires: bash, coreutils
 Requires: dmidecode, ethtool, hdparm
 Requires: perl perl-Test-Harness
 # infiniband-diags is not required, no ibstat == NOTRUN
+
+# Detect init system: use systemd for RHEL >= 10 or Fedora >= 40
+%if 0%{?rhel} >= 10 || 0%{?fedora} >= 40
+%define use_systemd 1
+BuildRequires: systemd
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+%else
+%define use_systemd 0
 Requires(post): /sbin/chkconfig
 Requires(preun): /sbin/chkconfig
+%endif
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 
@@ -29,23 +40,40 @@ rm -rf ${RPM_BUILD_ROOT}
 %{__mkdir_p} %{buildroot}%{_bindir}
 %{__mkdir_p} %{buildroot}%{_sysconfdir}/nodediag.d
 %{__mkdir_p} %{buildroot}%{_sysconfdir}/sysconfig/nodediag.d
-%{__mkdir_p} %{buildroot}%{_initrddir}
 %{__mkdir_p} %{buildroot}%{_mandir}/man1
 %{__mkdir_p} %{buildroot}%{libperl}/TAP/Formatter/Nodediag
 
 %{__install} -m 0755 nodediag %{buildroot}%{_bindir}/nodediag
 %{__install} -m 0755 diags/* %{buildroot}%{_sysconfdir}/nodediag.d/
 %{__install} -m 0644 nodediag.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/nodediag
-%{__install} -m 0755 nodediag.init %{buildroot}%{_initrddir}/nodediag
 %{__install} -m 0755 man/nodediag.1 %{buildroot}%{_mandir}/man1/nodediag.1
 %{__install} -m 0644 lib/TAP/Formatter/Nodediag.pm %{buildroot}%{libperl}/TAP/Formatter/Nodediag.pm
 %{__install} -m 0644 lib/TAP/Formatter/Nodediag/Session.pm %{buildroot}%{libperl}/TAP/Formatter/Nodediag/Session.pm
+
+%if %{use_systemd}
+%{__mkdir_p} %{buildroot}%{_unitdir}
+%{__install} -m 0644 nodediag.service %{buildroot}%{_unitdir}/nodediag.service
+%else
+%{__mkdir_p} %{buildroot}%{_initrddir}
+%{__install} -m 0755 nodediag.init %{buildroot}%{_initrddir}/nodediag
+%endif
 
 %clean
 if [ %{buildroot} != "/" ]; then
   %{__rm} -rf %{buildroot}
 fi
 
+%if %{use_systemd}
+%post
+%systemd_post nodediag.service
+
+%preun
+%systemd_preun nodediag.service
+
+%postun
+%systemd_postun nodediag.service
+
+%else
 %post
 if [ "$1" = "1" ]; then
   if [ -x /sbin/chkconfig ] ; then
@@ -59,6 +87,7 @@ if [ "$1" = "0" ]; then
     /sbin/chkconfig --del nodediag
   fi
 fi
+%endif
 
 %files
 %defattr(-,root,root,0755)
@@ -67,11 +96,15 @@ fi
 %dir %{_sysconfdir}/nodediag.d
 %{_sysconfdir}/nodediag.d/*
 %{_bindir}/nodediag
-%{_initrddir}/nodediag
 %{_mandir}/man1/*
 %{libperl}/TAP/Formatter/Nodediag.pm
 %dir %{libperl}/TAP/Formatter/Nodediag
 %{libperl}/TAP/Formatter/Nodediag/Session.pm
+%if %{use_systemd}
+%{_unitdir}/nodediag.service
+%else
+%{_initrddir}/nodediag
+%endif
 %defattr(-,root,root,0644)
 %config(noreplace) %{_sysconfdir}/sysconfig/nodediag
 


### PR DESCRIPTION
Add build-time version-based detection to use systemd unit file and scriptlets on RHEL >= 10 / Fedora >= 40, while building on other releases produces packages which continue using SysVinit.

For systemd installations, log to journald instead of /var/log/nodediag for consistency with modern services.

Recent RHEL/TOSS versions warn about init.d scripts during boot. The version-based approach allows configurations on older systems (e.g. TOSS 4/RHEL 8) to remain unchanged.

In the future, we could instead base the behavior on the presence of systemd. That would affect distros that use rpms but do not use systemd, which I believe to be very few.